### PR TITLE
fixing User-Agent to identify itself as browser

### DIFF
--- a/flexget/components/imdb/utils.py
+++ b/flexget/components/imdb/utils.py
@@ -15,7 +15,7 @@ logger = logger.bind(name='imdb.utils')
 # IMDb delivers a version of the page which is unparsable to unknown (and some known) user agents, such as requests'
 # Spoof the old urllib user agent to keep results consistent
 requests = Session()
-requests.headers.update({'User-Agent': 'Python-urllib/2.6'})
+requests.headers.update({'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0'})
 # requests.headers.update({'User-Agent': random.choice(USERAGENTS)})
 
 # this makes most of the titles to be returned in english translation, but not all of them


### PR DESCRIPTION
### Motivation for changes:
Failing IMDB lookup

### Detailed changes:
- basically changing the User Agent to be as a browser and not a bot

### Addressed issues/feature requests:
- Fixes #3612


